### PR TITLE
Change ttr from 180ns to 180s in Put

### DIFF
--- a/server.go
+++ b/server.go
@@ -190,7 +190,7 @@ func (s *server) Put(body []byte, name string) (uint64, error) {
 		Conn: s.bs,
 		Name: name,
 	}
-	return tube.Put(body, 1, 0, 180)
+	return tube.Put(body, 1, 0, 180*time.Second)
 }
 
 func (s *server) Stats() (map[string]string, error) {


### PR DESCRIPTION
The `Put` function specifies a TTR which evaluates to 180ns. This is quite low, so I've been running into `DEADLINE_SOON` errors when using `beany` to test a beanstalk client I'm writing. I'm assuming the TTR is meant to be 180s, not ns - this PR makes that change.